### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Normalizes line endings to use LF instead of CRLF.

Fixes issues when different OS's format line endings differently. LF will work on all OS's, whereas CRLF (windows's line feed) will not.

![image](https://github.com/JJeshua/ddsm-back-end/assets/79337598/8087e694-f761-4c97-8d92-036dc95d8c25)
